### PR TITLE
 docs: running in production

### DIFF
--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -7,7 +7,7 @@ This page contains all the information you need to bootstrap a production enviro
 The infrastructure consits of : 
 - a netrunner `server` that runs the game
 - a public `endpoint` that serves the card images and reverse proxy the `server`
-- a mongodb `database` that stores the data of the `server`
+- a MongoDB `database` that stores the data of the `server`
 
 ## Building a production docker image
 
@@ -74,7 +74,7 @@ Once the `database` has been populated, it is possible to disable the ports so t
 
 It is a good practice to back up the `database` and image files.
 
-Based on the official Mongodb documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other back up strategies can be implemented, simply [read the official Mongodb backup documentation](https ://www.mongodb.com/docs/manual/core/backups/).
+Based on the official MongoDB documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other back up strategies can be implemented, simply [read the official MongoDB backup documentation](https ://www.mongodb.com/docs/manual/core/backups/).
 
 Similarly, you can save the image folder specified in the docker compose file by copying it.
 

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -1,6 +1,6 @@
 This page contains all the information you need to bootstrap a production environment using docker.
 
-*Note*: the setup assumed that you are using the local filesystem to store data such as the images and the database. You can as well decide to use docker volumes instead.
+*Note*: the setup assumes that you are using the local filesystem to store data such as the card images and the database. You can as well decide to use docker volumes instead. See the official [docker volume documentation](https://docs.docker.com/storage/volumes/).
 
 ## Building a production docker image
 
@@ -15,26 +15,26 @@ Building the image takes quite some time as it compiles everything from scratch 
 ## Setting authentication secret
 
 To update the authentication secret:
-- edit docker/prod/prod.edn
-- set the value of the :web/auth :secret to a random long string
+- edit `docker/prod/prod.edn`
+- set the value of the `:web/auth` `:secret` to a long random string
 
 ## Running a production infrastructure
 
-The project provides a docker compose file that can be used to run the server, the database and the public endpoint.
+The project provides a docker compose file that can be used to run the server, the `database` and the public `endpoint`.
 
 It is required to update this file to reference your own image. To update proceed as follows:
-- with your favorite editor, open docker-compose.prod.yml
+- with your favorite editor, open `docker-compose.prod.yml`
 - locate the definition of the service called `server`
 - update the image name according the name chosen in the build step above
 
-You can then run the server by issuing the following command:
+You can then run the server by issuing the following command
 ```
 docker compose -f docker-compose.prod.yml up
 ```
 
 ## Populating the database
 
-To populate the database, run the following commands:
+To populate the `database`, run the following commands
 
 ```
 $ lein fetch 
@@ -46,7 +46,7 @@ Indexes successfully created.
 
 ## Restarting server
 
-Before you can access the server, you need to restart it to avoid an exception
+Before you can access the `server`, you need to restart it to avoid an exception
 
 ```
 docker compose -f docker-compose.prod.yml restart server
@@ -59,15 +59,15 @@ Netrunner is available at http://localhost:8042
 ## Reducing service exposure
 
 Once the database has been populated, it is possible to remove the ports exposed by the corresponding `database` as follows:
-- with your favorite editor, open docker-compose.prod.yml
+- with your favorite editor, open `docker-compose.prod.yml`
 - locate the definition of the service called `database`
 - comment out the port definition
 
 ## Backuping up and restoring
 
-The installation may require to back up the database and image files.
+It is a good practice to back up the `database` and image files.
 
-Based on the official Mongodb documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other backup strategies can be implemented, simply [read the documentation](https://www.mongodb.com/docs/manual/core/backups/#back-up-by-copying-underlying-data-files).
+Based on the official Mongodb documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other backup strategies can be implemented, simply [read the official Mongodb backup documentation](https://www.mongodb.com/docs/manual/core/backups/).
 
 Similarly, you can save the image folder specified in the docker compose file by copying it.
 
@@ -77,7 +77,7 @@ Restoring both database and images consists of copying back the backup to the lo
 
 ### First access raises exception
 
-Upon first access to the website you may face an exception "Tried to select server-card for The Shadow: Pulling the Strings". Restarting the server as follows is enough to make this go away.
+Upon first access to the website you may face an exception `Tried to select server-card for The Shadow: Pulling the Strings`. Restarting the server as follows is enough to make this go away.
 
 ```
 docker compose -f docker-compose.prod.yml restart server

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -1,6 +1,13 @@
 This page contains all the information you need to bootstrap a production environment using docker.
 
-*Note*: the setup assumes that you are using the local filesystem to store data such as the card images and the database. You can as well decide to use docker volumes instead. See the official [docker volume documentation](https://docs.docker.com/storage/volumes/).
+*Note*: the setup assumes that you are using the local filesystem to store data such as the card images and the database files. You can as well decide to use docker volumes instead. See the official [docker volume documentation](https://docs.docker.com/storage/volumes/).
+
+## Discovering the infrastructure
+
+The infrastructure consits of : 
+- a netrunner `server` that runs the game
+- a public `endpoint` that serves the card images and reverse proxy the `server`
+- a mongodb `database` that stores the data of the `server`
 
 ## Building a production docker image
 
@@ -14,27 +21,27 @@ Building the image takes quite some time as it compiles everything from scratch 
 
 ## Setting authentication secret
 
-To update the authentication secret:
-- edit `docker/prod/prod.edn`
+To update the authentication secret, proceed as follows:
+- with your favorite editor, edit `docker/prod/prod.edn`
 - set the value of the `:web/auth` `:secret` to a long random string
 
 ## Running a production infrastructure
 
 The project provides a docker compose file that can be used to run the server, the `database` and the public `endpoint`.
 
-It is required to update this file to reference your own image. To update proceed as follows:
-- with your favorite editor, open `docker-compose.prod.yml`
+It is required to update this file to reference your own image. To update, proceed as follows :
+- edit `docker-compose.prod.yml`
 - locate the definition of the service called `server`
 - update the image name according the name chosen in the build step above
 
-You can then run the server by issuing the following command
+You can then run the server by issuing the following command :
 ```
 docker compose -f docker-compose.prod.yml up
 ```
 
 ## Populating the database
 
-To populate the `database`, run the following commands
+To populate the `database`, run the following commands :
 
 ```
 $ lein fetch 
@@ -46,7 +53,7 @@ Indexes successfully created.
 
 ## Restarting server
 
-Before you can access the `server`, you need to restart it to avoid an exception
+Before you can access the `server`, you need to restart it to avoid an exception. To restart the `server`, proceed as follows :
 
 ```
 docker compose -f docker-compose.prod.yml restart server
@@ -54,24 +61,24 @@ docker compose -f docker-compose.prod.yml restart server
 
 ## Access the production instance
 
-Netrunner is available at http://localhost:8042
+You can acces Netrunner at [http://localhost:8042](http://localhost:8042).
 
 ## Reducing service exposure
 
-Once the database has been populated, it is possible to remove the ports exposed by the corresponding `database` as follows:
-- with your favorite editor, open `docker-compose.prod.yml`
+Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of docker internal network. To disable the prots, proceed as follows :
+- edit `docker-compose.prod.yml`
 - locate the definition of the service called `database`
-- comment out the port definition
+- comment out the `ports` definition
 
 ## Backuping up and restoring
 
 It is a good practice to back up the `database` and image files.
 
-Based on the official Mongodb documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other backup strategies can be implemented, simply [read the official Mongodb backup documentation](https://www.mongodb.com/docs/manual/core/backups/).
+Based on the official Mongodb documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other back up strategies can be implemented, simply [read the official Mongodb backup documentation](https ://www.mongodb.com/docs/manual/core/backups/).
 
 Similarly, you can save the image folder specified in the docker compose file by copying it.
 
-Restoring both database and images consists of copying back the backup to the locations specified in the docker compose file.
+Restoring both `database` and images consists of copying back the backup to the locations specified in the docker compose file.
 
 ## Known issues
 

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -1,0 +1,84 @@
+This page contains all the information you need to bootstrap a production environment using docker.
+
+*Note*: the setup assumed that you are using the local filesystem to store data such as the images and the database. You can as well decide to use docker volumes instead.
+
+## Building a production docker image
+
+To build the production docker image, proceed as follows
+
+```
+docker build -t <your-org>/netrunner . -f docker/prod/Dockerfile
+ ```
+
+Building the image takes quite some time as it compiles everything from scratch and generate the uber jar.
+
+## Setting authentication secret
+
+To update the authentication secret:
+- edit docker/prod/prod.edn
+- set the value of the :web/auth :secret to a random long string
+
+## Running a production infrastructure
+
+The project provides a docker compose file that can be used to run the server, the database and the public endpoint.
+
+It is required to update this file to reference your own image. To update proceed as follows:
+- with your favorite editor, open docker-compose.prod.yml
+- locate the definition of the service called `server`
+- update the image name according the name chosen in the build step above
+
+You can then run the server by issuing the following command:
+```
+docker compose -f docker-compose.prod.yml up
+```
+
+## Populating the database
+
+To populate the database, run the following commands:
+
+```
+$ lein fetch 
+1648 cards imported
+
+$ lein create-indexes
+Indexes successfully created.
+```
+
+## Restarting server
+
+Before you can access the server, you need to restart it to avoid an exception
+
+```
+docker compose -f docker-compose.prod.yml restart server
+```
+
+## Access the production instance
+
+Netrunner is available at http://localhost:8042
+
+## Reducing service exposure
+
+Once the database has been populated, it is possible to remove the ports exposed by the corresponding `database` as follows:
+- with your favorite editor, open docker-compose.prod.yml
+- locate the definition of the service called `database`
+- comment out the port definition
+
+## Backuping up and restoring
+
+The installation may require to back up the database and image files.
+
+Based on the official Mongodb documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other backup strategies can be implemented, simply [read the documentation](https://www.mongodb.com/docs/manual/core/backups/#back-up-by-copying-underlying-data-files).
+
+Similarly, you can save the image folder specified in the docker compose file by copying it.
+
+Restoring both database and images consists of copying back the backup to the locations specified in the docker compose file.
+
+## Known issues
+
+### First access raises exception
+
+Upon first access to the website you may face an exception "Tried to select server-card for The Shadow: Pulling the Strings". Restarting the server as follows is enough to make this go away.
+
+```
+docker compose -f docker-compose.prod.yml restart server
+```

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -9,32 +9,52 @@ The infrastructure consists of :
 - a public `endpoint` that serves the card images and reverse proxy the `server`
 - a MongoDB `database` that stores the data of the `server`
 
-## Building a production Docker image
+## Generating a production docker compose file
+
+The project provides a Docker compose file that can be used to run the `server`, the `database` and the public `endpoint`.
+The `lein generate-docker` command helps with creating and maintaining the docker compose file based on the template available at `docker/prod/docker-compose.yml.tpl` or any template specified with the `-t` option.
+
+```
+Usage: lein generate-docker [options]
+
+Options:
+  -t, --template PATH                      docker/prod/docker-compose.yml.tpl  Path to docker-compose template
+  -o, --output PATH                        docker-compose.prod.yml             Path to generated docker-compose file
+  -i, --image IMAGE-NAME                                                       Image name is required
+  -p, --port PORT                          1042                                Port exposing Netrunner
+  -r, --folder-resources FOLDER-RESOURCES  ./resources/public                  Path to the public resources
+  -f, --config CONFIG-FILE                 ./docker/prod/prod.edn              Path to the configuration file
+  -m, --image-mongodb IMAGE-NAME-MONGODB   mongo                               Image name of MongoDB
+  -d, --folder-mongodb FOLDER-MONGODB      ./data                              Folder of the MongoDB database
+  -c, --close-mongodb                                                          Disable MongoDB connectivity outside of Docker internal network
+```
+
+To generate the production docker compose file with the default settings and the image name `your-name/your-image`, proceed as follows
+
+```
+lein generate-docker --name your-name/image-name
+```
+
+## Building a production Docker imageb
 
 To build the production Docker image, proceed as follows
 
 ```
-docker build -t <your-org>/netrunner . -f docker/prod/Dockerfile
+docker compose -f docker-compose.prod.yml build
  ```
 
 Building the image takes quite some time as it compiles everything from scratch and generate the uber jar.
 
 ## Setting authentication secret
 
-To update the authentication secret, proceed as follows:
+To update the authentication secret in the default configuration file, proceed as follows:
 - with your favorite editor, edit `docker/prod/prod.edn`
 - set the value of the `:web/auth` `:secret` to a long random string
 
 ## Running a production infrastructure
 
-The project provides a Docker compose file that can be used to run the server, the `database` and the public `endpoint`.
+To run the production infrastructure proceed as follows
 
-It is required to update this file to reference your own image. To update, proceed as follows :
-- edit `docker-compose.prod.yml`
-- locate the definition of the service called `server`
-- update the image name according the name chosen in the build step above
-
-You can then run the server by issuing the following command :
 ```
 docker compose -f docker-compose.prod.yml up
 ```
@@ -65,10 +85,11 @@ You can access Netrunner at [http://localhost:8042](http://localhost:8042).
 
 ## Reducing service exposure
 
-Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of Docker internal network. To disable the ports, proceed as follows :
-- edit `docker-compose.prod.yml`
-- locate the definition of the service called `database`
-- comment out the `ports` definition
+Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of Docker internal network. To disable the ports, regenerate the production docker-compose file with the image name `your-name/your-iamge` as follows
+
+```
+lein generate-docker --image your-name/your-image -c
+```
 
 ## Backing up and restoring
 

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -1,10 +1,10 @@
 This page contains all the information you need to bootstrap a production environment using Docker.
 
-*Note*: the setup assumes that you are using the local filesystem to store data such as the card images and the database files. You can as well decide to use Docker volumes instead. See the official [Docker volume documentation](https://docs.docker.com/storage/volumes/).
+*Note*: the setup assumes that you are using the local file system to store data such as the card images and the database files. You can as well decide to use Docker volumes instead. See the official [Docker volume documentation](https://docs.docker.com/storage/volumes/).
 
 ## Discovering the infrastructure
 
-The infrastructure consits of : 
+The infrastructure consists of :
 - a netrunner `server` that runs the game
 - a public `endpoint` that serves the card images and reverse proxy the `server`
 - a MongoDB `database` that stores the data of the `server`
@@ -61,16 +61,16 @@ docker compose -f docker-compose.prod.yml restart server
 
 ## Access the production instance
 
-You can acces Netrunner at [http://localhost:8042](http://localhost:8042).
+You can access Netrunner at [http://localhost:8042](http://localhost:8042).
 
 ## Reducing service exposure
 
-Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of Docker internal network. To disable the prots, proceed as follows :
+Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of Docker internal network. To disable the ports, proceed as follows :
 - edit `docker-compose.prod.yml`
 - locate the definition of the service called `database`
 - comment out the `ports` definition
 
-## Backuping up and restoring
+## Backing up and restoring
 
 It is a good practice to back up the `database` and image files.
 

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -1,6 +1,6 @@
-This page contains all the information you need to bootstrap a production environment using docker.
+This page contains all the information you need to bootstrap a production environment using Docker.
 
-*Note*: the setup assumes that you are using the local filesystem to store data such as the card images and the database files. You can as well decide to use docker volumes instead. See the official [docker volume documentation](https://docs.docker.com/storage/volumes/).
+*Note*: the setup assumes that you are using the local filesystem to store data such as the card images and the database files. You can as well decide to use Docker volumes instead. See the official [Docker volume documentation](https://docs.docker.com/storage/volumes/).
 
 ## Discovering the infrastructure
 
@@ -9,9 +9,9 @@ The infrastructure consits of :
 - a public `endpoint` that serves the card images and reverse proxy the `server`
 - a MongoDB `database` that stores the data of the `server`
 
-## Building a production docker image
+## Building a production Docker image
 
-To build the production docker image, proceed as follows
+To build the production Docker image, proceed as follows
 
 ```
 docker build -t <your-org>/netrunner . -f docker/prod/Dockerfile
@@ -27,7 +27,7 @@ To update the authentication secret, proceed as follows:
 
 ## Running a production infrastructure
 
-The project provides a docker compose file that can be used to run the server, the `database` and the public `endpoint`.
+The project provides a Docker compose file that can be used to run the server, the `database` and the public `endpoint`.
 
 It is required to update this file to reference your own image. To update, proceed as follows :
 - edit `docker-compose.prod.yml`
@@ -65,7 +65,7 @@ You can acces Netrunner at [http://localhost:8042](http://localhost:8042).
 
 ## Reducing service exposure
 
-Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of docker internal network. To disable the prots, proceed as follows :
+Once the `database` has been populated, it is possible to disable the ports so that the `database` is not accessible outside of Docker internal network. To disable the prots, proceed as follows :
 - edit `docker-compose.prod.yml`
 - locate the definition of the service called `database`
 - comment out the `ports` definition
@@ -74,11 +74,11 @@ Once the `database` has been populated, it is possible to disable the ports so t
 
 It is a good practice to back up the `database` and image files.
 
-Based on the official MongoDB documentation, you can simply turn off the database and copy the data folder specified in the docker compose volume section. Other back up strategies can be implemented, simply [read the official MongoDB backup documentation](https ://www.mongodb.com/docs/manual/core/backups/).
+Based on the official MongoDB documentation, you can simply turn off the database and copy the data folder specified in the Docker compose volume section. Other back up strategies can be implemented, simply [read the official MongoDB backup documentation](https ://www.mongodb.com/docs/manual/core/backups/).
 
-Similarly, you can save the image folder specified in the docker compose file by copying it.
+Similarly, you can save the image folder specified in the Docker compose file by copying it.
 
-Restoring both `database` and images consists of copying back the backup to the locations specified in the docker compose file.
+Restoring both `database` and images consists of copying back the backup to the locations specified in the Docker compose file.
 
 ## Known issues
 

--- a/Running-in-production.md
+++ b/Running-in-production.md
@@ -35,7 +35,7 @@ To generate the production docker compose file with the default settings and the
 lein generate-docker --name your-name/image-name
 ```
 
-## Building a production Docker imageb
+## Building a production Docker image
 
 To build the production Docker image, proceed as follows
 


### PR DESCRIPTION
This PR adds a new page documenting the steps to run [mtgred/netrunner](https://github.com/mtgred/netrunner) in production. 